### PR TITLE
Feature/remove bootstrap relative import

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,10 @@ Use the `col-ms-*` classes.
 In your LESS, somewhere after importing Bootstrap, import the LESS file:
 
 ```less
-@import (reference) "bower_components/bootstrap/less/bootstrap";
+@import "bower_components/bootstrap/less/bootstrap";
 @import "bower_components/bootstrap-grid-ms/less/bootstrap-grid-ms";
 ```
 
-Optionally, you may instead define the relative path to the Bootstrap LESS file:
-```less
-// Relative path to Boostrap LESS file from bootstrap-grid-ms LESS file:
-@bootstrap-grid-ms-bootstrap-path "../../bootstrap/less/bootstrap";
-@import "bower_components/bootstrap-grid-ms/less/bootstrap-grid-ms";
-```
 ### SCSS/Sass
 
 You will need an SCSS/Sass version of Bootstrap, which is not included in this module's default Bower dependencies.

--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ Use the `col-ms-*` classes.
 In your LESS, somewhere after importing Bootstrap, import the LESS file:
 
 ```less
-// Relative path to Boostrap LESS file from bootstrap-grid-ms LESS file:
-@bootstrap-grid-ms-bootstrap-path: "../../bootstrap/less/bootstrap";
+@import (reference) "bower_components/bootstrap/less/bootstrap";
 @import "bower_components/bootstrap-grid-ms/less/bootstrap-grid-ms";
 ```
 
+Optionally, you may instead define the relative path to the Bootstrap LESS file:
+```less
+// Relative path to Boostrap LESS file from bootstrap-grid-ms LESS file:
+@bootstrap-grid-ms-bootstrap-path "../../bootstrap/less/bootstrap";
+@import "bower_components/bootstrap-grid-ms/less/bootstrap-grid-ms";
+```
 ### SCSS/Sass
 
 You will need an SCSS/Sass version of Bootstrap, which is not included in this module's default Bower dependencies.

--- a/less/bootstrap-grid-ms.less
+++ b/less/bootstrap-grid-ms.less
@@ -24,7 +24,7 @@
 //@bootstrap-grid-ms-bootstrap-path: "../../bootstrap/less/bootstrap";
 
 
-@import (reference) ~"@{bootstrap-grid-ms-bootstrap-path}";
+@import (reference, optional) ~"@{bootstrap-grid-ms-bootstrap-path}";
 
 // Mid-Small breakpoint
 

--- a/less/bootstrap-grid-ms.less
+++ b/less/bootstrap-grid-ms.less
@@ -14,17 +14,6 @@
 // See https://github.com/twbs/bootstrap/issues/10203 for more info.
 // Forked from: https://gist.github.com/Jakobud/8eca95f07a3b50453cd7
 // Original gist: https://gist.github.com/andyl/6360906
-//
-// Instructions: Add the following to the end of bootstrap.less
-//
-// @import "bootstrap-ms";
-//
-
-// Importers must define relative path to Bootstrap LESS file, e.g.:
-//@bootstrap-grid-ms-bootstrap-path: "../../bootstrap/less/bootstrap";
-
-
-@import (reference, optional) ~"@{bootstrap-grid-ms-bootstrap-path}";
 
 // Mid-Small breakpoint
 


### PR DESCRIPTION
https://github.com/adjohnson916/bootstrap-grid-ms/issues/7
This removes `@bootstrap-grid-ms-bootstrap-path` from the LESS file and updates the Readme to accommodate the change.
