### PR TITLE
Add the !default keyword so that the mid-small width can be overridden.

### DIFF
--- a/scss/_bootstrap-grid-ms.scss
+++ b/scss/_bootstrap-grid-ms.scss
@@ -22,7 +22,7 @@
 //
 
 // Mid-Small breakpoint
-$screen-ms: 480px;
+$screen-ms: 480px !default;
 $screen-ms-min: $screen-ms;
 $screen-ms-max: ($screen-sm-min - 1);
 


### PR DESCRIPTION
This changes allows users to set the MS breakpoint. I prefer 544px over 480px, and this change allows me to use bootstrap-grid-ms this way.

In Less, variables can be overridden because of how Less lazy loads values, but in Sass, the !default keyword is needed to achieve this.
